### PR TITLE
Remove non-functional download targets; point to github release

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@ layout: default
     <p>
         The truest font editor.
     </p>
-    <a href="https://github.com/trufont/trufont/releases/download/0.4.0/TruFont.exe.fixed.zip" class="btn btn-primary btn-large dl windows">Windows Install</a>
-    <a href="https://github.com/trufont/trufont/releases/download/0.4.0/TruFont.app.zip" class="btn btn-primary btn-large dl macos">Mac OS Install</a>
-    <a href="https://github.com/trufont/trufont/releases/download/0.4.0/TruFont.zip" class="btn btn-primary btn-large dl gnulinux">GNU+Linux Install</a>
-    <a href="https://github.com/trufont/trufont/releases/tag/0.4.0" class="btn btn-large default">All releases</a>
+    <a href="https://github.com/trufont/trufont/releases/latest" class="btn btn-primary btn-large dl windows">Windows Install</a>
+    <a href="https://github.com/trufont/trufont/releases/latest" class="btn btn-primary btn-large dl macos">Mac OS Install</a>
+    <a href="https://github.com/trufont/trufont/releases/latest" class="btn btn-primary btn-large dl gnulinux">GNU+Linux Install</a>
+    <a href="https://github.com/trufont/trufont/releases" class="btn btn-large default">All releases</a>
 </article>
 <script src="js/site.js"></script>


### PR DESCRIPTION
As mentioned in Trufont issue 728, having the binary download point to the source is more user friendly than pointing to non-existent files. So, while we wait for someone to contribute build infrastructure, this pull request at least improves the user experience.